### PR TITLE
[#3] bug – fixed gap between cards

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -10,20 +10,17 @@ body {
 }
 
 .cards_container {
-  display: grid;
+  display: flex;
+  flex-flow: row wrap;
   align-items: center;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  justify-content: center;
   gap: 1rem;
-  margin: 20px;
-  padding: 30px;
 }
 
 .card {
-  position: relative;
-
   background-color: aliceblue;
-  width: 30vw;
-  height: 50vh;
+  width: 240px;
+  height: 400px;
   margin: 10px;
   padding: 30px;
 


### PR DESCRIPTION
closes #3 

Now they always have a gap, even in wider screens.

I also:
– cleaned up some styles that weren't needed.
– changed from grid to flexbox, I think it responds better
– changed the size of the cards from a proportion, to fixed sizes:
I don't want the sizes to change.